### PR TITLE
fix: enable the ability to use most react-native libs with storybook

### DIFF
--- a/storybook/.storybook-web/webpack.config.js
+++ b/storybook/.storybook-web/webpack.config.js
@@ -1,9 +1,9 @@
+const { resolve } = require("path");
+const { withUnimodules } = require("@expo/webpack-config/addons");
 const alias = require('../../aliases.config.js');
-const path = require('path');
 
 module.exports = ({ config }) => {
-  config.resolve.extensions = ['.js', '.json', '.web.js', '.web.jsx', '.jsx'];
-
+  config.resolve.alias['@storybook/react-native'] = '@storybook/react';
   config.module.rules.push({
     test: /\.tsx?$/,
     use: [
@@ -23,10 +23,5 @@ module.exports = ({ config }) => {
     ]
   });
 
-  config.resolve.alias = {
-    '@storybook/react-native': '@storybook/react',
-    'react-native': 'react-native-web'
-  };
-
-  return config;
+  return withUnimodules(config, { projectRoot: resolve(__dirname, "../../") });
 };


### PR DESCRIPTION
This change uses expo's webpack config as the basis for spinning up the storybook, allowing you to use most if not all expo specific or even react-native specific libraries with storybook. 

An added benefit is it becomes much easier to create stories that might incorporate third-party libraries like react-native-elements into stories, without having to maintain the work yourself.