### PR TITLE
fix: ADRS folder is duplicate of ADRs, causing issues on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Polaris is an oppinionated curated set of libraries, tools, and conventions asse
 <!-- Internal Links -->
 
 [push notifications]: /docs/pushNotifications.md
-[adrs]: /docs/ADRS/README.md
+[adrs]: /docs/ADRs/README.md
 
 <!-- Images -->
 

--- a/docs/ADRS/README.md
+++ b/docs/ADRS/README.md
@@ -1,5 +1,0 @@
-# Documentation of design decisions that have been made in Poliaris
-
-Polaris is an opinionated scafolding. Decisions have been made as to the technologies used therein, and these are documented here.
-
-## index


### PR DESCRIPTION
A small issue with the docs, causing issues in windows.

`docs/ADRS/` folder looked like to be a duplicate of `ADRs`, so I removed and fixed link in README.md