### PR TITLE
docs: add componenets stories for our docs utils

### DIFF
--- a/docs/polaris_UI.md
+++ b/docs/polaris_UI.md
@@ -1,6 +1,6 @@
 # Polaris UI
 
-## Atomic Design for UI Components
+# Atomic Design for UI Components
 
 Polaris has Atomic Design structure for its UI components.
 
@@ -87,7 +87,82 @@ Storybook's configuration and support files located inside `/storybook` folder i
 
 See the [Quick start guide](/quickstart/) for instructions on how to run Storybook.
 
-## SVGs
+## Storybook components
+
+Set of components to facilitate documenting and writing stories. Examples can be found in the UI stories under `Storybook Helpers/Components`
+
+### `<DocSection>`
+
+A top level container for wrapping sections of stories
+
+### `<DocText>`
+
+A text element with accessabilityRole or a link, primarily used for describing elements inside DocSection
+
+### `<DocCode>`
+
+Presents a block of code in a story
+
+Template literals can be used and will be trimmed to fit
+
+### `<DocItem>`
+
+Utility for documenting a component, you can provide basic info, render, and code example
+
+### `<DocExternalLink>`
+
+Displays a link to an external href
+
+### `<InlineCode>`
+
+Display an inline code snippet
+
+### `<PropTable>`
+
+Displays a table of props similar to the addon-docs prop table.
+
+### `<StyleList>`
+
+Display prop information for a single prop
+
+### `<TextList>`
+
+Display a list of text items
+
+### `<ThemeSwitcher>`
+
+Displays a toggle to switch the theme on/off
+
+### `<DividerHorizontal>`
+
+Horizontal divider
+
+### `<DividerVertical>`
+
+Vertical divider
+
+### `<StoryPage>`
+
+Wrapper for all stories in a story file.
+
+Apply with .addDecorator when using storiesOf or include in the decorators array if using CSF format.
+
+```
+  storiesOf('Main/Sub', module)
+ .addDecorator(storyFn => (
+   <StoryPage
+     title="Title"
+     url="components/myComponent"
+     storyFn={storyFn}
+   >
+     An example story page
+   </StoryPage>
+ ))
+```
+
+The storyFn must be passed in from the decorators callback.
+
+# SVGs
 
 Be aware that imported SVGs are automatically converted to normal React components. This is possible via `react-native-svg-transformer` library on native and `@svgr/webpack` loader on web. If you are interested in how the generated component looks like, head over to the [svgr documentation](https://react-svgr.com/docs/getting-started/).
 
@@ -104,3 +179,7 @@ and treat it like a normal React component:
 ```
 
 Note that props on the svg component are forwarded to the root `<svg>` element.
+
+# Styling
+
+Polaris uses [styled-components](https://styled-components.com/) to handle component styling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12183,6 +12183,58 @@
         "warning": "^4.0.3"
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test:ci": "jest --ci",
     "prestorybook": "rnstl",
     "storybook:web": "start-storybook -p 9001 -c ./storybook/.storybook-web",
-    "storybook:ios": "run-p prestorybook && RUN_STORYBOOK=true expo start -c --ios",
-    "storybook:android": "run-p prestorybook && RUN_STORYBOOK=true expo start -c --android",
+    "storybook:ios": "run-p prestorybook && cross-env RUN_STORYBOOK=true expo start -c --ios",
+    "storybook:android": "run-p prestorybook && cross-env RUN_STORYBOOK=true expo start -c --android",
     "test:watch": "jest --watch",
     "checks": "run-p lint:fix && run-p lint && run-p test",
     "e2e:web:open": "cypress open",
@@ -87,7 +87,8 @@
   "config": {
     "react-native-storybook-loader": {
       "searchDir": [
-        "./src"
+        "./src",
+        "./storybook/story-components"
       ],
       "pattern": "**/stories/{*.stories.common,*.stories.native}.js",
       "outputFile": "./storybook/storyLoader.js"
@@ -125,6 +126,7 @@
     "babel-plugin-inline-dotenv": "^1.5.0",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-preset-expo": "^8.2.3",
+    "cross-env": "^7.0.2",
     "cypress": "^4.9.0",
     "docsify-cli": "^4.4.1",
     "eslint": "^7.3.1",

--- a/src/components/atoms/button/stories/button.stories.common.js
+++ b/src/components/atoms/button/stories/button.stories.common.js
@@ -2,18 +2,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react-native'
 import { action } from '@storybook/addon-actions'
 import { withKnobs, text } from '@storybook/addon-knobs'
-import StoryPage, {
-  DocText,
-  DocSection,
-  DocItem,
-  DocCode,
-  DocExternalLink,
-  InlineCode,
-  PropTable,
-  StyleList,
-  TextList,
-  ThemeSwitcher
-} from 'storybook/story-components'
+import StoryPage, { DocItem, ThemeSwitcher } from 'storybook/story-components'
 
 import Button from '../'
 
@@ -36,117 +25,19 @@ storiesOf('Atoms/Button', module)
   ))
   .addDecorator(withKnobs)
   .add('With title', () => (
-    <DocItem
-      sectionTitle="With title"
-      name="title"
-      description="The title to be used for the buttons content"
-      typeInfo="string"
-      required
-      example={{
-        render,
-        code:
-          '<Button title="A button with a title" onPress={handleButtonPress}>'
-      }}
-    />
-  ))
-  .add('With onPress', () => (
-    <DocItem
-      sectionTitle="With onPress"
-      name="onPress"
-      description="Callback for button press"
-      typeInfo="func"
-      required
-      example={{
-        render,
-        code: '<Button title="A button" onPress={handleButtonPress}>'
-      }}
-    />
-  ))
-  .add('Themed Button', () => (
-    <DocSection title="Themed Button">
-      <ThemeSwitcher />
-      <Button title="Themed button" onPress={action('Button Pressed')} />
-    </DocSection>
-  ))
-  .add('An example external link', () => (
-    <DocSection title="An example external link">
-      <DocExternalLink href="http://example.com">
-        A link to an external resource
-      </DocExternalLink>
-      <DocText>
-        Note: @storybook/addon-links is incompatible with
-        @storybook/react-native and so internal storybook links are not possible
-        at present.
-      </DocText>
-    </DocSection>
-  ))
-  .add('An example StyleList', () => (
-    <DocSection title="An example external StyleList">
-      <DocText>
-        Use to display type information for classes/functions that are not React
-        components
-      </DocText>
-      <StyleList
-        types={[
-          { label: 'Item 1', name: 'Name 1', typeInfo: 'Some Type Info' },
-          { label: 'Item 2', name: 'Name 2', typeInfo: 'Some Type Info' },
-          { label: 'Item 3', name: 'Name 3', typeInfo: 'Some Type Info' }
-        ]}
-      ></StyleList>
-    </DocSection>
-  ))
-  .add('An example ItemList', () => (
-    <DocSection title="An example ItemList">
-      <DocText>A plain text item list example</DocText>
-      <TextList
-        items={[
-          'Item 1',
-          'A multiline list item requires a lot of text in order for it to loop onto the following line',
-          'Item 3'
-        ]}
-      ></TextList>
-    </DocSection>
-  ))
-  .add('An example propTable', () => (
-    <DocSection title="An example propTable">
-      <DocText>
-        Alternatively, a single story can include a prop table to cover all
-        options at once
-      </DocText>
-      <PropTable
-        propData={[
-          { name: 'title', type: 'string', required: true },
-          { name: 'onPress', type: 'func', required: true },
-          { name: 'color', type: 'string', required: false }
-        ]}
-      />
+    <>
       <DocItem
+        sectionTitle="With title"
+        name="title"
+        description="The title to be used for the buttons content"
+        typeInfo="string"
+        required
         example={{
           render,
-          code: '<Button title="A red button" onPress={handleButtonPress}>'
+          code:
+            '<Button title="A button with a title" onPress={handleButtonPress}>'
         }}
       />
-    </DocSection>
-  ))
-  .add('An example code section', () => (
-    <DocSection>
-      <DocText>Code sections can be included independently of DocItem</DocText>
-      <DocCode
-        code={`
-<Button
-  title="A title for a button"
-  onPress={someHandler}
-  color="teal">
-       `}
-      />
-      <DocText>
-        Note: new lines and spaces at the start and end are trimmed
-      </DocText>
-      <DocText>
-        Inline code can be inserted with{' '}
-        <InlineCode
-          code={`<InlineCode code={\`<Button title="A title" />\`} />`}
-        />
-      </DocText>
-    </DocSection>
+      <ThemeSwitcher />
+    </>
   ))

--- a/storybook/.storybook-web/main.js
+++ b/storybook/.storybook-web/main.js
@@ -1,4 +1,12 @@
 module.exports = {
-  stories: ['../../src/**/*.stories.js', '../../src/**/stories/*.web.js', '../../src/**/stories/*.common.js'],
-  addons: ['@storybook/addon-actions/register', '@storybook/addon-knobs/register']
-};
+  stories: [
+    '../../src/**/*.stories.js',
+    '../../src/**/stories/*.web.js',
+    '../../src/**/stories/*.common.js',
+    '../../storybook/story-components/**/stories/*.common.js'
+  ],
+  addons: [
+    '@storybook/addon-actions/register',
+    '@storybook/addon-knobs/register'
+  ]
+}

--- a/storybook/story-components/stories/story-components.stories.common.js
+++ b/storybook/story-components/stories/story-components.stories.common.js
@@ -1,0 +1,349 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react-native'
+import StoryPage, {
+  DocSection,
+  DocCode,
+  DocText,
+  InlineCode,
+  DocExternalLink,
+  DocItem,
+  StyleList,
+  PropTable,
+  ThemeSwitcher
+} from 'storybook/story-components'
+import { View } from 'react-native'
+
+storiesOf('Storybook Helpers/Components', module)
+  .addDecorator(storyFn => (
+    <StoryPage
+      title="<DocItem>"
+      url="storybook/story-components/doc-item"
+      storyFn={storyFn}
+      screens={[{ name: '/doc-item' }]}
+    >
+      Utility for documenting a component
+    </StoryPage>
+  ))
+
+  .add('<DocItem>', () => {
+    return (
+      <DocSection>
+        <DocText>you can provide basic info, render, and code example</DocText>
+        <PropTable
+          propData={[
+            { name: 'sectionTitle', type: 'string', required: false },
+            { name: 'name', type: 'func', required: false },
+            { name: 'description', type: 'string', required: false },
+            { name: 'typeInfo', type: 'string', required: false },
+            { name: 'example', type: '{ render,\n code }', required: false },
+            { name: 'label', type: 'string', required: false },
+            { name: 'required', type: 'string', required: false },
+            { name: 'defaultValue', type: 'string', required: false }
+          ]}
+        />
+        <DocCode
+          code={`
+<DocItem
+sectionTitle="Section title"
+name="propName"
+description="The title to be used for the example"
+typeInfo="string"
+required
+example={{
+  render:<DocText>test</DocText>,
+  code:
+    '<DocText>test</DocText>'
+  }}
+/>
+      `}
+        />
+
+        <DocSection title="Example:">
+          <DocItem
+            sectionTitle="Section title"
+            name="propName"
+            description="The title to be used for the example"
+            typeInfo="string"
+            required
+            example={{
+              render: <DocText>test</DocText>,
+              code: '<DocText>test</DocText>'
+            }}
+          />
+        </DocSection>
+      </DocSection>
+    )
+  })
+
+storiesOf('Storybook Helpers/Components', module)
+  .addDecorator(storyFn => (
+    <StoryPage
+      title="<DocSection>"
+      url="storybook/story-components/doc-section"
+      storyFn={storyFn}
+      screens={[{ name: '/doc-section' }]}
+    >
+      A Document section block.
+    </StoryPage>
+  ))
+  .add('<DocSection>', () => {
+    return (
+      <DocItem
+        name="title"
+        typeInfo="string"
+        required
+        example={{
+          render: (
+            <DocSection title="Title">
+              <DocText>Encapuslate story docs</DocText>
+            </DocSection>
+          ),
+          code: `
+<DocSection title="Title">
+  <DocText>
+    Encapuslate story docs
+  </DocText>
+</DocSection>
+        `
+        }}
+      />
+    )
+  })
+
+storiesOf('Storybook Helpers/Components', module)
+  .addDecorator(storyFn => (
+    <StoryPage
+      title="<DocText>"
+      url="storybook/story-components/doc-text"
+      storyFn={storyFn}
+      screens={[{ name: '/doc-text' }]}
+    >
+      A document text block
+    </StoryPage>
+  ))
+  .add('<DocText>', () => {
+    return (
+      <DocItem
+        example={{
+          render: <DocText>Some text</DocText>,
+          code: `<DockText>Some text</DockText>`
+        }}
+      />
+    )
+  })
+
+storiesOf('Storybook Helpers/Components', module)
+  .addDecorator(storyFn => (
+    <StoryPage
+      title="<DocCode>"
+      url="storybook/story-components/doc-code"
+      storyFn={storyFn}
+      screens={[{ name: '/doc-code' }]}
+    >
+      A Document code block
+    </StoryPage>
+  ))
+  .add('<DocCode>', () => {
+    return (
+      <DocSection>
+        <DocItem
+          name="code"
+          description="Code sections can be included independently of DocItem"
+          typeInfo="string"
+          required
+          example={{
+            render: (
+              <DocCode
+                code={`
+<Button
+  title="A title for a button"
+  onPress={someHandler}
+  color="teal">`}
+              />
+            ),
+            code: `
+<DocCode
+  code={${`
+    <Button
+      title="A title for a button"
+      onPress={someHandler}
+      color="teal">
+    `}}
+/>`
+          }}
+        />
+        <DocText>
+          Note: new lines and spaces at the start and end are trimmed
+        </DocText>
+        <DocText>
+          Inline code can be inserted with{' '}
+          <InlineCode
+            code={`<InlineCode code={\`<Button title="A title" />\`} />`}
+          />
+        </DocText>
+      </DocSection>
+    )
+  })
+
+storiesOf('Storybook Helpers/Components', module)
+  .addDecorator(storyFn => (
+    <StoryPage
+      title="<InlineCode>"
+      url="storybook/story-components/inline-code"
+      storyFn={storyFn}
+      screens={[{ name: '/inline-code' }]}
+    >
+      Inline code block
+    </StoryPage>
+  ))
+  .add('<InlineCode>', () => {
+    return (
+      <DocItem
+        name="code"
+        typeInfo="string"
+        required
+        example={{
+          render: <InlineCode code={`inline-code example`} />,
+          code: `<InlineCode code={'inline-code example'}/>`
+        }}
+      />
+    )
+  })
+
+storiesOf('Storybook Helpers/Components', module)
+  .addDecorator(storyFn => (
+    <StoryPage
+      title="<DocExternalLink>"
+      url="storybook/story-components/doc-external-link"
+      storyFn={storyFn}
+      screens={[{ name: '/inline-code' }]}
+    >
+      A link to an external resource
+    </StoryPage>
+  ))
+  .add('<DocExternalLink>', () => {
+    return (
+      <DocItem
+        sectionTitle="External link"
+        name="href"
+        description={`Note: @storybook/addon-links is incompatible with @storybook/react-native and so internal storybook links are not possible at present.`}
+        typeInfo="string"
+        required
+        example={{
+          render: (
+            <DocExternalLink href="http://example.com">
+              A link to an external resource
+            </DocExternalLink>
+          ),
+          code: `<DocExternalLink href="http://example.com">A link to an external resource</DocExternalLink>`
+        }}
+      />
+    )
+  })
+
+storiesOf('Storybook Helpers/Components', module)
+  .addDecorator(storyFn => (
+    <StoryPage
+      title="<PropTable>"
+      url="storybook/story-components/prop-table"
+      storyFn={storyFn}
+      screens={[{ name: '/prop-table' }]}
+    >
+      Table to list component properties
+    </StoryPage>
+  ))
+  .add('<PropTable>', () => {
+    return (
+      <DocItem
+        sectionTitle="External link"
+        name="propData"
+        typeInfo="[{ name: 'propertyName', type: 'string', required: false }]"
+        required
+        example={{
+          render: (
+            <PropTable
+              propData={[
+                { name: 'propertyName', type: 'string', required: false }
+              ]}
+            />
+          ),
+          code: `
+<PropTable
+  propData={[
+    { name: 'propertyName', type: 'string', required: false },
+  ]}
+/>
+          `
+        }}
+      />
+    )
+  })
+
+storiesOf('Storybook Helpers/Components', module)
+  .addDecorator(storyFn => (
+    <StoryPage
+      title="<StyleList>"
+      url="storybook/story-components/style-list"
+      storyFn={storyFn}
+      screens={[{ name: '/style-list' }]}
+    >
+      An example external StyleList
+    </StoryPage>
+  ))
+  .add('<StyleList>', () => {
+    return (
+      <DocItem
+        sectionTitle="Style list"
+        name="types"
+        description="Use to display type information for classes/functions that are not React components"
+        typeInfo="{ label: 'Item 1', name: 'Name 1', typeInfo: 'Some Type Info' }"
+        required
+        example={{
+          render: (
+            <StyleList
+              types={[
+                { label: 'Item 1', name: 'Name 1', typeInfo: 'Some Type Info' },
+                { label: 'Item 2', name: 'Name 2', typeInfo: 'Some Type Info' },
+                { label: 'Item 3', name: 'Name 3', typeInfo: 'Some Type Info' }
+              ]}
+            />
+          ),
+          code: `
+<StyleList
+  types={[
+    { label: 'Item 1', name: 'Name 1', typeInfo: 'Some Type Info' },
+    { label: 'Item 2', name: 'Name 2', typeInfo: 'Some Type Info' },
+    { label: 'Item 3', name: 'Name 3', typeInfo: 'Some Type Info' }
+  ]}
+/>
+          `
+        }}
+      />
+    )
+  })
+
+storiesOf('Storybook Helpers/Components', module)
+  .addDecorator(storyFn => (
+    <StoryPage
+      title="<ThemeSwitcher>"
+      url="storybook/story-components/theme-switcher"
+      storyFn={storyFn}
+      screens={[{ name: '/theme-switcher' }]}
+    >
+      Theme switcher
+    </StoryPage>
+  ))
+  .add('<ThemeSwitcher>', () => {
+    return (
+      <DocSection>
+        <DocItem
+          sectionTitle="Theme switcher"
+          description="Displays a toggle to switch the theme on/off"
+          example={{
+            render: <ThemeSwitcher />,
+            code: '<ThemeSwitcher />'
+          }}
+        />
+      </DocSection>
+    )
+  })


### PR DESCRIPTION
* Added additional docs regarding the story book, all the custom storybook components now have their own story entries. 

* Added `cross-env` for windows development compatibility.

Closes #52