### PR TITLE
Map example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29258,6 +29258,11 @@
       "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz",
       "integrity": "sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ=="
     },
+    "react-native-maps": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-0.27.1.tgz",
+      "integrity": "sha512-HygBkZBecTnIVRYrSiLRAvu4OmXOYso/A7c6Cy73HkOh9CgGV8Ap5eBea24tvmFGptjj5Hg8AJ94/YbmWK1Okw=="
+    },
     "react-native-modal": {
       "version": "11.5.6",
       "resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-11.5.6.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.2.tar.gz",
     "react-native-elements": "^2.0.4",
     "react-native-gesture-handler": "~1.6.0",
+    "react-native-maps": "^0.27.1",
     "react-native-reanimated": "~1.9.0",
     "react-native-safe-area-context": "~3.0.7",
     "react-native-screens": "~2.9.0",

--- a/src/components/views/MapView/index.native.jsx
+++ b/src/components/views/MapView/index.native.jsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect } from 'react'
+// docs availible on https://github.com/react-native-maps/react-native-maps
+import MapViewNative, { Callout, Marker } from 'react-native-maps'
+import Container from 'components/atoms/container'
+import styled from 'styled-components/native'
+
+const startingRegion = {
+  latitude: 37.78825,
+  longitude: -122.4324,
+  latitudeDelta: 0.0922,
+  longitudeDelta: 0.0421
+}
+
+const Title = styled.Text`
+  padding: 3px 3px;
+  font-size: 16px;
+  font-weight: bold;
+`
+
+const Description = styled.Text`
+  text-align: left;
+  color: #3f3f3f;
+  padding: 0 3px;
+  text-align: left;
+  align-self: stretch;
+  max-width: 200px;
+`
+
+const generateMarkers = (nr, region) => {
+  const markersGen = []
+  for (let i = 0; i < nr; i++) {
+    markersGen.push({
+      name: 'Lorem ipsum dolor sit amet',
+      id: `${Date.now()}-${i}`,
+      description: `
+consectetur adipiscing elit. Duis ultrices lectus a lorem vulputate, 
+semper urna ornare. Morbi aliquet felis non sem vehicula, vel rutrum
+nisl tristique`,
+      coords: {
+        latitude:
+          region.latitude + region.latitudeDelta * (Math.random() - 0.5),
+        longitude:
+          region.longitude + region.longitudeDelta * (Math.random() - 0.5)
+      }
+    })
+  }
+  return markersGen
+}
+
+export const MapView = () => {
+  const [region, setRegion] = useState(startingRegion)
+  const [markers, setMarkers] = useState([])
+  useEffect(() => {
+    const newMarkers = [...markers, ...generateMarkers(10, region)]
+    if (newMarkers.length > 50) {
+      newMarkers.splice(0, 10)
+    }
+    setMarkers(newMarkers)
+  }, [region])
+
+  return (
+    <Container>
+      <MapViewNative
+        onRegionChangeComplete={r => setRegion(r)}
+        style={{ width: '100%', height: '100%' }}
+        initialRegion={startingRegion}
+      >
+        {markers.map(({ coords, name, description, id }) => {
+          return (
+            <Marker coordinate={coords} key={id}>
+              <Callout>
+                <Container>
+                  <Title>{name}</Title>
+                  <Description>{description}</Description>
+                </Container>
+              </Callout>
+            </Marker>
+          )
+        })}
+      </MapViewNative>
+    </Container>
+  )
+}

--- a/src/components/views/home/index.jsx
+++ b/src/components/views/home/index.jsx
@@ -32,7 +32,10 @@ export const HomeScreen = () => {
       <LinkButton title={t('home:responsiveButton')} path="/responsive" />
       <LinkButton title={t('home:authButton')} path="/auth" />
       {Platform.OS !== 'web' && (
-        <LinkButton title={t('home:qrCodeButton')} path="/qrCode" />
+        <>
+          <LinkButton title={t('home:qrCodeButton')} path="/qrCode" />
+          <LinkButton title={t('home:mapButton')} path="/map" />
+        </>
       )}
     </Container>
   )

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -14,7 +14,8 @@
     "pushNotificationsButton": "Go to Push Notifications",
     "responsiveButton": "Go to responsive example",
     "authButton": "Go to auth example",
-    "qrCodeButton": "Go to QR Code"
+    "qrCodeButton": "Go to QR Code",
+    "mapButton": "Go to map"
   },
   "viewOne": {
     "title": "View One",
@@ -78,6 +79,9 @@
       "light": "Light",
       "dark": "Dark"
     }
+  },
+  "map": {
+    "title": "Map"
   },
   "errors": {
     "404": "404: Page {{path}}not found"

--- a/src/routes/index.native.js
+++ b/src/routes/index.native.js
@@ -1,5 +1,6 @@
 import { Camera } from 'components/views'
 import { QRCode } from 'components/views/QRCode'
+import { MapView } from 'components/views/MapView'
 
 import routes, { defaultPath, routeShape } from './index.common'
 
@@ -10,6 +11,12 @@ const nativeOnlyRoutes = [
     View: QRCode,
     name: 'qrCode:title',
     menuIndex: 11
+  },
+  {
+    path: '/map',
+    View: MapView,
+    name: 'map:title',
+    menuIndex: 12
   }
 ]
 


### PR DESCRIPTION
I added an example of use of: `react-native-maps`

It currently does not support web, but web should not be hard to implement on our side, with the help of google libs.

The example generates some random markers with title and description around the view area, very simplistic and rough. I have made a custom `<Callout>` (used for pin popups. contents can be styled and different elements added to it easily). As of right now you can not really embed links into it, but you can use on `onPress` of the callout if actions/links are required. 



