### PR TITLE
ios build and upload

### DIFF
--- a/.github/workflows/e2e.android.yml
+++ b/.github/workflows/e2e.android.yml
@@ -43,8 +43,7 @@ jobs:
       - run: expo doctor
       - run: expo diagnostics
       # TODO: what about a server when the app is running on a device?
-      - run: expo export --dev --public-url http://localhost:5000
-      # TODO: check if running the server is needed to do the build
+      - run: expo export --clear --force --dev --public-url http://localhost:5000 --output-dir dist
       - run: npx serve dist &
       - run: |
           echo "$EXPO_ANDROID_KEYSTORE_BASE64" > keystore.jks.base64
@@ -55,59 +54,6 @@ jobs:
           EXPO_ANDROID_KEYSTORE_ALIAS: ${{ secrets.EXPO_ANDROID_KEYSTORE_ALIAS }}
           EXPO_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.EXPO_ANDROID_KEYSTORE_PASSWORD }}
           EXPO_ANDROID_KEY_PASSWORD: ${{ secrets.EXPO_ANDROID_KEY_PASSWORD }}
-      - uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: build/
-
-  ios-build:
-    runs-on: macos-latest
-    if: ${{ !github.event.inputs.artifact-run-id }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-      - id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.turtle
-          key: ${{ runner.os }}-turtle
-          restore-keys: |
-            ${{ runner.os }}-turtle
-      - uses: actions/setup-java@v1.4.3
-        with:
-          java-version: '8'
-      - uses: expo/expo-github-action@v5
-        with:
-          expo-cache: true
-          expo-token: ${{ secrets.EXPO_TOKEN }}
-      - run: yarn
-      - run: expo doctor
-      - run: expo diagnostics
-      # TODO: what about a server when the app is running on a device?
-      - run: expo export --dev --public-url http://localhost:5000
-      # TODO: check if running the server is needed to do the build
-      - run: npx serve dist &
-      - run: |
-          echo "$EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64" > cert.p12.base64
-          echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
-          base64 --decode cert.p12.base64 > cert.p12
-          base64 --decode profile.mobileprovision.base64 > profile.mobileprovision
-          yarn build:local:ios -- --type=archive --output=build/polaris.ipa --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
-        env:
-          EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
-          EXPO_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.EXPO_IOS_PROVISIONING_PROFILE_BASE64 }}
-          EXPO_IOS_TEAM_ID: ${{ secrets.EXPO_IOS_TEAM_ID }}
-          EXPO_IOS_DIST_P12_PASSWORD: ${{ secrets.EXPO_IOS_DIST_P12_PASSWORD }}
       - uses: actions/upload-artifact@v2
         with:
           name: build
@@ -144,63 +90,3 @@ jobs:
           api-level: 29
           working-directory: e2e
           script: yarn e2e:android:run
-
-  ios-release:
-    needs: ios-build
-    if: always()
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-      - name: Download artifact from run ${{ github.event.inputs.artifact-run-id }}
-        uses: dawidd6/action-download-artifact@v2
-        if: ${{ github.event.inputs.artifact-run-id }}
-        with:
-          workflow: ${{ github.workflow }}
-          name: build
-          path: build
-          run_id: ${{ github.event.inputs.artifact-run-id }}
-      - uses: actions/download-artifact@v2
-        if: ${{ !github.event.inputs.artifact-run-id }}
-        with:
-          name: build
-          path: build
-      - run: fastlane ios_release
-        env:
-          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.IOS_API_KEY_KEY_ID }}
-          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.IOS_API_KEY_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.IOS_API_KEY_KEY_CONTENT_BASE64 }}
-
-  upload:
-    needs: e2e
-    if: always()
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-      - name: Download artifact from run ${{ github.event.inputs.artifact-run-id }}
-        uses: dawidd6/action-download-artifact@v2
-        if: ${{ github.event.inputs.artifact-run-id }}
-        with:
-          workflow: ${{ github.workflow }}
-          name: build
-          path: build
-          run_id: ${{ github.event.inputs.artifact-run-id }}
-      - uses: actions/download-artifact@v2
-        if: ${{ !github.event.inputs.artifact-run-id }}
-        with:
-          name: build
-          path: build
-      - uses: expo/expo-github-action@v5
-        with:
-          expo-cache: true
-          expo-token: ${{ secrets.EXPO_TOKEN }}
-      - run: |
-          echo "$PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON" > play-store-account-key.json
-          expo upload:android --key ./play-store-account-key.json --path ./build/polaris.apk --type apk --release-status draft
-        env:
-          PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON }}

--- a/.github/workflows/e2e.android.yml
+++ b/.github/workflows/e2e.android.yml
@@ -9,67 +9,67 @@ on:
         description: 'Run id from which to get earlier artifacts, instead of generating new ones'
 
 jobs:
-  build:
-    if: ${{ !github.event.inputs.artifact-run-id }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-      - id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.turtle
-          key: ${{ runner.os }}-turtle
-          restore-keys: |
-            ${{ runner.os }}-turtle
-      - uses: actions/setup-java@v1.4.3
-        with:
-          java-version: '8'
-      - uses: expo/expo-github-action@v5
-        with:
-          expo-cache: true
-          expo-token: ${{ secrets.EXPO_TOKEN }}
-      - run: yarn
-      - run: expo doctor
-      - run: expo diagnostics
-      # TODO: what about a server when the app is running on a device?
-      - run: expo export --dev --public-url http://localhost:5000
-      # TODO: check if running the server is needed to do the build
-      - run: npx serve dist &
-      - run: |
-          echo "$EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64" > cert.p12.base64
-          echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
-          base64 --decode cert.p12.base64 > cert.p12
-          base64 --decode profile.mobileprovision.base64 > profile.mobileprovision
-          yarn build:local:ios -- --type=archive --build-dir=. --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
-        env:
-          EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
-          EXPO_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.EXPO_IOS_PROVISIONING_PROFILE_BASE64 }}
-          EXPO_IOS_TEAM_ID: ${{ secrets.EXPO_IOS_TEAM_ID }}
-          EXPO_IOS_DIST_P12_PASSWORD: ${{ secrets.EXPO_IOS_DIST_P12_PASSWORD }}
-      - run: |
-          echo "$EXPO_ANDROID_KEYSTORE_BASE64" > keystore.jks.base64
-          base64 --decode keystore.jks.base64 > keystore.jks
-          yarn build:local:android -- --public-url http://localhost:5000/android-index.json --allow-non-https-public-url --keystore-path ./keystore.jks --keystore-alias $EXPO_ANDROID_KEYSTORE_ALIAS
-        env:
-          EXPO_ANDROID_KEYSTORE_BASE64: ${{ secrets.EXPO_ANDROID_KEYSTORE_BASE64 }}
-          EXPO_ANDROID_KEYSTORE_ALIAS: ${{ secrets.EXPO_ANDROID_KEYSTORE_ALIAS }}
-          EXPO_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.EXPO_ANDROID_KEYSTORE_PASSWORD }}
-          EXPO_ANDROID_KEY_PASSWORD: ${{ secrets.EXPO_ANDROID_KEY_PASSWORD }}
-      - uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: build/
+  # build:
+  #   if: ${{ !github.event.inputs.artifact-run-id }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 14.x
+  #     - id: yarn-cache-dir-path
+  #       run: echo "::set-output name=dir::$(yarn cache dir)"
+  #     - uses: actions/cache@v2
+  #       id: yarn-cache
+  #       with:
+  #         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+  #         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-yarn-
+  #     - uses: actions/cache@v2
+  #       with:
+  #         path: ~/.turtle
+  #         key: ${{ runner.os }}-turtle
+  #         restore-keys: |
+  #           ${{ runner.os }}-turtle
+  #     - uses: actions/setup-java@v1.4.3
+  #       with:
+  #         java-version: '8'
+  #     - uses: expo/expo-github-action@v5
+  #       with:
+  #         expo-cache: true
+  #         expo-token: ${{ secrets.EXPO_TOKEN }}
+  #     - run: yarn
+  #     - run: expo doctor
+  #     - run: expo diagnostics
+  #     # TODO: what about a server when the app is running on a device?
+  #     - run: expo export --dev --public-url http://localhost:5000
+  #     # TODO: check if running the server is needed to do the build
+  #     - run: npx serve dist &
+  #     - run: |
+  #         echo "$EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64" > cert.p12.base64
+  #         echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
+  #         base64 --decode cert.p12.base64 > cert.p12
+  #         base64 --decode profile.mobileprovision.base64 > profile.mobileprovision
+  #         yarn build:local:ios -- --type=archive --build-dir=. --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
+  #       env:
+  #         EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+  #         EXPO_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.EXPO_IOS_PROVISIONING_PROFILE_BASE64 }}
+  #         EXPO_IOS_TEAM_ID: ${{ secrets.EXPO_IOS_TEAM_ID }}
+  #         EXPO_IOS_DIST_P12_PASSWORD: ${{ secrets.EXPO_IOS_DIST_P12_PASSWORD }}
+  #     - run: |
+  #         echo "$EXPO_ANDROID_KEYSTORE_BASE64" > keystore.jks.base64
+  #         base64 --decode keystore.jks.base64 > keystore.jks
+  #         yarn build:local:android -- --public-url http://localhost:5000/android-index.json --allow-non-https-public-url --keystore-path ./keystore.jks --keystore-alias $EXPO_ANDROID_KEYSTORE_ALIAS
+  #       env:
+  #         EXPO_ANDROID_KEYSTORE_BASE64: ${{ secrets.EXPO_ANDROID_KEYSTORE_BASE64 }}
+  #         EXPO_ANDROID_KEYSTORE_ALIAS: ${{ secrets.EXPO_ANDROID_KEYSTORE_ALIAS }}
+  #         EXPO_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.EXPO_ANDROID_KEYSTORE_PASSWORD }}
+  #         EXPO_ANDROID_KEY_PASSWORD: ${{ secrets.EXPO_ANDROID_KEY_PASSWORD }}
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: build
+  #         path: build/
 
   build-ios:
     runs-on: macos-latest
@@ -123,66 +123,66 @@ jobs:
           name: build
           path: build/
 
-  e2e:
-    needs: build
-    if: always()
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-      - name: Download artifact from run ${{ github.event.inputs.artifact-run-id }}
-        uses: dawidd6/action-download-artifact@v2
-        if: ${{ github.event.inputs.artifact-run-id }}
-        with:
-          workflow: ${{ github.workflow }}
-          name: build
-          path: build
-          run_id: ${{ github.event.inputs.artifact-run-id }}
-      - uses: actions/download-artifact@v2
-        if: ${{ !github.event.inputs.artifact-run-id }}
-        with:
-          name: build
-          path: build
-      - run: yarn
-        working-directory: e2e
-      - run: npx appium-doctor --android
-      - run: npx appium &
-      - uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 29
-          working-directory: e2e
-          script: yarn e2e:android:run
+  # e2e:
+  #   needs: build
+  #   if: always()
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 14.x
+  #     - name: Download artifact from run ${{ github.event.inputs.artifact-run-id }}
+  #       uses: dawidd6/action-download-artifact@v2
+  #       if: ${{ github.event.inputs.artifact-run-id }}
+  #       with:
+  #         workflow: ${{ github.workflow }}
+  #         name: build
+  #         path: build
+  #         run_id: ${{ github.event.inputs.artifact-run-id }}
+  #     - uses: actions/download-artifact@v2
+  #       if: ${{ !github.event.inputs.artifact-run-id }}
+  #       with:
+  #         name: build
+  #         path: build
+  #     - run: yarn
+  #       working-directory: e2e
+  #     - run: npx appium-doctor --android
+  #     - run: npx appium &
+  #     - uses: reactivecircus/android-emulator-runner@v2
+  #       with:
+  #         api-level: 29
+  #         working-directory: e2e
+  #         script: yarn e2e:android:run
 
-  upload:
-    needs: e2e
-    if: always()
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-      - name: Download artifact from run ${{ github.event.inputs.artifact-run-id }}
-        uses: dawidd6/action-download-artifact@v2
-        if: ${{ github.event.inputs.artifact-run-id }}
-        with:
-          workflow: ${{ github.workflow }}
-          name: build
-          path: build
-          run_id: ${{ github.event.inputs.artifact-run-id }}
-      - uses: actions/download-artifact@v2
-        if: ${{ !github.event.inputs.artifact-run-id }}
-        with:
-          name: build
-          path: build
-      - uses: expo/expo-github-action@v5
-        with:
-          expo-cache: true
-          expo-token: ${{ secrets.EXPO_TOKEN }}
-      - run: |
-          echo "$PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON" > play-store-account-key.json
-          expo upload:android --key ./play-store-account-key.json --path ./build/polaris.apk --type apk --release-status draft
-        env:
-          PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON }}
+  # upload:
+  #   needs: e2e
+  #   if: always()
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 14.x
+  #     - name: Download artifact from run ${{ github.event.inputs.artifact-run-id }}
+  #       uses: dawidd6/action-download-artifact@v2
+  #       if: ${{ github.event.inputs.artifact-run-id }}
+  #       with:
+  #         workflow: ${{ github.workflow }}
+  #         name: build
+  #         path: build
+  #         run_id: ${{ github.event.inputs.artifact-run-id }}
+  #     - uses: actions/download-artifact@v2
+  #       if: ${{ !github.event.inputs.artifact-run-id }}
+  #       with:
+  #         name: build
+  #         path: build
+  #     - uses: expo/expo-github-action@v5
+  #       with:
+  #         expo-cache: true
+  #         expo-token: ${{ secrets.EXPO_TOKEN }}
+  #     - run: |
+  #         echo "$PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON" > play-store-account-key.json
+  #         expo upload:android --key ./play-store-account-key.json --path ./build/polaris.apk --type apk --release-status draft
+  #       env:
+  #         PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON }}

--- a/.github/workflows/e2e.android.yml
+++ b/.github/workflows/e2e.android.yml
@@ -51,7 +51,7 @@ jobs:
           echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
           base64 --decode cert.p12.base64 > cert.p12
           base64 --decode profile.mobileprovision.base64 > profile.mobileprovision
-          turtle build:ios --type=archive --build-dir=. --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
+          yarn build:local:ios -- --type=archive --build-dir=. --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
         env:
           EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
           EXPO_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.EXPO_IOS_PROVISIONING_PROFILE_BASE64 }}

--- a/.github/workflows/e2e.android.yml
+++ b/.github/workflows/e2e.android.yml
@@ -47,17 +47,6 @@ jobs:
       # TODO: check if running the server is needed to do the build
       - run: npx serve dist &
       - run: |
-          echo "$EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64" > cert.p12.base64
-          echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
-          base64 --decode cert.p12.base64 > cert.p12
-          base64 --decode profile.mobileprovision.base64 > profile.mobileprovision
-          yarn build:local:ios -- --type=archive --build-dir=. --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
-        env:
-          EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
-          EXPO_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.EXPO_IOS_PROVISIONING_PROFILE_BASE64 }}
-          EXPO_IOS_TEAM_ID: ${{ secrets.EXPO_IOS_TEAM_ID }}
-          EXPO_IOS_DIST_P12_PASSWORD: ${{ secrets.EXPO_IOS_DIST_P12_PASSWORD }}
-      - run: |
           echo "$EXPO_ANDROID_KEYSTORE_BASE64" > keystore.jks.base64
           base64 --decode keystore.jks.base64 > keystore.jks
           yarn build:local:android -- --public-url http://localhost:5000/android-index.json --allow-non-https-public-url --keystore-path ./keystore.jks --keystore-alias $EXPO_ANDROID_KEYSTORE_ALIAS

--- a/.github/workflows/e2e.android.yml
+++ b/.github/workflows/e2e.android.yml
@@ -71,7 +71,7 @@ jobs:
   #         name: build
   #         path: build/
 
-  build-ios:
+  ios-build:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -154,6 +154,34 @@ jobs:
   #         api-level: 29
   #         working-directory: e2e
   #         script: yarn e2e:android:run
+
+  ios-release:
+    needs: ios-build
+    if: always()
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Download artifact from run ${{ github.event.inputs.artifact-run-id }}
+        uses: dawidd6/action-download-artifact@v2
+        if: ${{ github.event.inputs.artifact-run-id }}
+        with:
+          workflow: ${{ github.workflow }}
+          name: build
+          path: build
+          run_id: ${{ github.event.inputs.artifact-run-id }}
+      - uses: actions/download-artifact@v2
+        if: ${{ !github.event.inputs.artifact-run-id }}
+        with:
+          name: build
+          path: build
+      - run: fastlane ios_release
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.IOS_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.IOS_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.IOS_API_KEY_KEY_CONTENT_BASE64 }}
 
   # upload:
   #   needs: e2e

--- a/.github/workflows/e2e.android.yml
+++ b/.github/workflows/e2e.android.yml
@@ -50,7 +50,7 @@ jobs:
           echo "$EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64" > cert.p12.base64
           echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
           base64 --decode -i cert.p12.base64 -o cert.p12
-          base64 --decode -i profile.mobileprovision.base64 -o 
+          base64 --decode -i profile.mobileprovision.base64 -o profile.mobileprovision.base64
           turtle build:ios --type=archive --build-dir=. --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
         env:
           EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}

--- a/.github/workflows/e2e.android.yml
+++ b/.github/workflows/e2e.android.yml
@@ -71,6 +71,58 @@ jobs:
           name: build
           path: build/
 
+  build-ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - uses: actions/cache@v2
+        with:
+          path: ~/.turtle
+          key: ${{ runner.os }}-turtle
+          restore-keys: |
+            ${{ runner.os }}-turtle
+      - uses: actions/setup-java@v1.4.3
+        with:
+          java-version: '8'
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-cache: true
+          expo-token: ${{ secrets.EXPO_TOKEN }}
+      - run: yarn
+      - run: expo doctor
+      - run: expo diagnostics
+      # TODO: what about a server when the app is running on a device?
+      - run: expo export --dev --public-url http://localhost:5000
+      # TODO: check if running the server is needed to do the build
+      - run: npx serve dist &
+      - run: |
+          echo "$EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64" > cert.p12.base64
+          echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
+          base64 --decode cert.p12.base64 > cert.p12
+          base64 --decode profile.mobileprovision.base64 > profile.mobileprovision
+          yarn build:local:ios -- --type=archive --output=build/polaris.ipa --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
+        env:
+          EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          EXPO_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.EXPO_IOS_PROVISIONING_PROFILE_BASE64 }}
+          EXPO_IOS_TEAM_ID: ${{ secrets.EXPO_IOS_TEAM_ID }}
+          EXPO_IOS_DIST_P12_PASSWORD: ${{ secrets.EXPO_IOS_DIST_P12_PASSWORD }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build/
+
   e2e:
     needs: build
     if: always()

--- a/.github/workflows/e2e.android.yml
+++ b/.github/workflows/e2e.android.yml
@@ -73,6 +73,7 @@ jobs:
 
   ios-build:
     runs-on: macos-latest
+    if: ${{ !github.event.inputs.artifact-run-id }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/e2e.android.yml
+++ b/.github/workflows/e2e.android.yml
@@ -9,67 +9,67 @@ on:
         description: 'Run id from which to get earlier artifacts, instead of generating new ones'
 
 jobs:
-  # build:
-  #   if: ${{ !github.event.inputs.artifact-run-id }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 14.x
-  #     - id: yarn-cache-dir-path
-  #       run: echo "::set-output name=dir::$(yarn cache dir)"
-  #     - uses: actions/cache@v2
-  #       id: yarn-cache
-  #       with:
-  #         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-  #         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-yarn-
-  #     - uses: actions/cache@v2
-  #       with:
-  #         path: ~/.turtle
-  #         key: ${{ runner.os }}-turtle
-  #         restore-keys: |
-  #           ${{ runner.os }}-turtle
-  #     - uses: actions/setup-java@v1.4.3
-  #       with:
-  #         java-version: '8'
-  #     - uses: expo/expo-github-action@v5
-  #       with:
-  #         expo-cache: true
-  #         expo-token: ${{ secrets.EXPO_TOKEN }}
-  #     - run: yarn
-  #     - run: expo doctor
-  #     - run: expo diagnostics
-  #     # TODO: what about a server when the app is running on a device?
-  #     - run: expo export --dev --public-url http://localhost:5000
-  #     # TODO: check if running the server is needed to do the build
-  #     - run: npx serve dist &
-  #     - run: |
-  #         echo "$EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64" > cert.p12.base64
-  #         echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
-  #         base64 --decode cert.p12.base64 > cert.p12
-  #         base64 --decode profile.mobileprovision.base64 > profile.mobileprovision
-  #         yarn build:local:ios -- --type=archive --build-dir=. --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
-  #       env:
-  #         EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
-  #         EXPO_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.EXPO_IOS_PROVISIONING_PROFILE_BASE64 }}
-  #         EXPO_IOS_TEAM_ID: ${{ secrets.EXPO_IOS_TEAM_ID }}
-  #         EXPO_IOS_DIST_P12_PASSWORD: ${{ secrets.EXPO_IOS_DIST_P12_PASSWORD }}
-  #     - run: |
-  #         echo "$EXPO_ANDROID_KEYSTORE_BASE64" > keystore.jks.base64
-  #         base64 --decode keystore.jks.base64 > keystore.jks
-  #         yarn build:local:android -- --public-url http://localhost:5000/android-index.json --allow-non-https-public-url --keystore-path ./keystore.jks --keystore-alias $EXPO_ANDROID_KEYSTORE_ALIAS
-  #       env:
-  #         EXPO_ANDROID_KEYSTORE_BASE64: ${{ secrets.EXPO_ANDROID_KEYSTORE_BASE64 }}
-  #         EXPO_ANDROID_KEYSTORE_ALIAS: ${{ secrets.EXPO_ANDROID_KEYSTORE_ALIAS }}
-  #         EXPO_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.EXPO_ANDROID_KEYSTORE_PASSWORD }}
-  #         EXPO_ANDROID_KEY_PASSWORD: ${{ secrets.EXPO_ANDROID_KEY_PASSWORD }}
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: build
-  #         path: build/
+  build:
+    if: ${{ !github.event.inputs.artifact-run-id }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - uses: actions/cache@v2
+        with:
+          path: ~/.turtle
+          key: ${{ runner.os }}-turtle
+          restore-keys: |
+            ${{ runner.os }}-turtle
+      - uses: actions/setup-java@v1.4.3
+        with:
+          java-version: '8'
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-cache: true
+          expo-token: ${{ secrets.EXPO_TOKEN }}
+      - run: yarn
+      - run: expo doctor
+      - run: expo diagnostics
+      # TODO: what about a server when the app is running on a device?
+      - run: expo export --dev --public-url http://localhost:5000
+      # TODO: check if running the server is needed to do the build
+      - run: npx serve dist &
+      - run: |
+          echo "$EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64" > cert.p12.base64
+          echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
+          base64 --decode cert.p12.base64 > cert.p12
+          base64 --decode profile.mobileprovision.base64 > profile.mobileprovision
+          yarn build:local:ios -- --type=archive --build-dir=. --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
+        env:
+          EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          EXPO_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.EXPO_IOS_PROVISIONING_PROFILE_BASE64 }}
+          EXPO_IOS_TEAM_ID: ${{ secrets.EXPO_IOS_TEAM_ID }}
+          EXPO_IOS_DIST_P12_PASSWORD: ${{ secrets.EXPO_IOS_DIST_P12_PASSWORD }}
+      - run: |
+          echo "$EXPO_ANDROID_KEYSTORE_BASE64" > keystore.jks.base64
+          base64 --decode keystore.jks.base64 > keystore.jks
+          yarn build:local:android -- --public-url http://localhost:5000/android-index.json --allow-non-https-public-url --keystore-path ./keystore.jks --keystore-alias $EXPO_ANDROID_KEYSTORE_ALIAS
+        env:
+          EXPO_ANDROID_KEYSTORE_BASE64: ${{ secrets.EXPO_ANDROID_KEYSTORE_BASE64 }}
+          EXPO_ANDROID_KEYSTORE_ALIAS: ${{ secrets.EXPO_ANDROID_KEYSTORE_ALIAS }}
+          EXPO_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.EXPO_ANDROID_KEYSTORE_PASSWORD }}
+          EXPO_ANDROID_KEY_PASSWORD: ${{ secrets.EXPO_ANDROID_KEY_PASSWORD }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build/
 
   ios-build:
     runs-on: macos-latest
@@ -124,37 +124,37 @@ jobs:
           name: build
           path: build/
 
-  # e2e:
-  #   needs: build
-  #   if: always()
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 14.x
-  #     - name: Download artifact from run ${{ github.event.inputs.artifact-run-id }}
-  #       uses: dawidd6/action-download-artifact@v2
-  #       if: ${{ github.event.inputs.artifact-run-id }}
-  #       with:
-  #         workflow: ${{ github.workflow }}
-  #         name: build
-  #         path: build
-  #         run_id: ${{ github.event.inputs.artifact-run-id }}
-  #     - uses: actions/download-artifact@v2
-  #       if: ${{ !github.event.inputs.artifact-run-id }}
-  #       with:
-  #         name: build
-  #         path: build
-  #     - run: yarn
-  #       working-directory: e2e
-  #     - run: npx appium-doctor --android
-  #     - run: npx appium &
-  #     - uses: reactivecircus/android-emulator-runner@v2
-  #       with:
-  #         api-level: 29
-  #         working-directory: e2e
-  #         script: yarn e2e:android:run
+  e2e:
+    needs: build
+    if: always()
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Download artifact from run ${{ github.event.inputs.artifact-run-id }}
+        uses: dawidd6/action-download-artifact@v2
+        if: ${{ github.event.inputs.artifact-run-id }}
+        with:
+          workflow: ${{ github.workflow }}
+          name: build
+          path: build
+          run_id: ${{ github.event.inputs.artifact-run-id }}
+      - uses: actions/download-artifact@v2
+        if: ${{ !github.event.inputs.artifact-run-id }}
+        with:
+          name: build
+          path: build
+      - run: yarn
+        working-directory: e2e
+      - run: npx appium-doctor --android
+      - run: npx appium &
+      - uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          working-directory: e2e
+          script: yarn e2e:android:run
 
   ios-release:
     needs: ios-build
@@ -184,34 +184,34 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.IOS_API_KEY_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.IOS_API_KEY_KEY_CONTENT_BASE64 }}
 
-  # upload:
-  #   needs: e2e
-  #   if: always()
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 14.x
-  #     - name: Download artifact from run ${{ github.event.inputs.artifact-run-id }}
-  #       uses: dawidd6/action-download-artifact@v2
-  #       if: ${{ github.event.inputs.artifact-run-id }}
-  #       with:
-  #         workflow: ${{ github.workflow }}
-  #         name: build
-  #         path: build
-  #         run_id: ${{ github.event.inputs.artifact-run-id }}
-  #     - uses: actions/download-artifact@v2
-  #       if: ${{ !github.event.inputs.artifact-run-id }}
-  #       with:
-  #         name: build
-  #         path: build
-  #     - uses: expo/expo-github-action@v5
-  #       with:
-  #         expo-cache: true
-  #         expo-token: ${{ secrets.EXPO_TOKEN }}
-  #     - run: |
-  #         echo "$PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON" > play-store-account-key.json
-  #         expo upload:android --key ./play-store-account-key.json --path ./build/polaris.apk --type apk --release-status draft
-  #       env:
-  #         PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON }}
+  upload:
+    needs: e2e
+    if: always()
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Download artifact from run ${{ github.event.inputs.artifact-run-id }}
+        uses: dawidd6/action-download-artifact@v2
+        if: ${{ github.event.inputs.artifact-run-id }}
+        with:
+          workflow: ${{ github.workflow }}
+          name: build
+          path: build
+          run_id: ${{ github.event.inputs.artifact-run-id }}
+      - uses: actions/download-artifact@v2
+        if: ${{ !github.event.inputs.artifact-run-id }}
+        with:
+          name: build
+          path: build
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-cache: true
+          expo-token: ${{ secrets.EXPO_TOKEN }}
+      - run: |
+          echo "$PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON" > play-store-account-key.json
+          expo upload:android --key ./play-store-account-key.json --path ./build/polaris.apk --type apk --release-status draft
+        env:
+          PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON }}

--- a/.github/workflows/e2e.android.yml
+++ b/.github/workflows/e2e.android.yml
@@ -47,6 +47,17 @@ jobs:
       # TODO: check if running the server is needed to do the build
       - run: npx serve dist &
       - run: |
+          echo "$EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64" > cert.p12.base64
+          echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
+          base64 --decode -i cert.p12.base64 -o cert.p12
+          base64 --decode -i profile.mobileprovision.base64 -o 
+          turtle build:ios --type=archive --build-dir=. --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
+        env:
+          EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          EXPO_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.EXPO_IOS_PROVISIONING_PROFILE_BASE64 }}
+          EXPO_IOS_TEAM_ID: ${{ secrets.EXPO_IOS_TEAM_ID }}
+          EXPO_IOS_DIST_P12_PASSWORD: ${{ secrets.EXPO_IOS_DIST_P12_PASSWORD }}
+      - run: |
           echo "$EXPO_ANDROID_KEYSTORE_BASE64" > keystore.jks.base64
           base64 --decode keystore.jks.base64 > keystore.jks
           yarn build:local:android -- --public-url http://localhost:5000/android-index.json --allow-non-https-public-url --keystore-path ./keystore.jks --keystore-alias $EXPO_ANDROID_KEYSTORE_ALIAS

--- a/.github/workflows/e2e.android.yml
+++ b/.github/workflows/e2e.android.yml
@@ -49,8 +49,8 @@ jobs:
       - run: |
           echo "$EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64" > cert.p12.base64
           echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
-          base64 --decode -i cert.p12.base64 -o cert.p12
-          base64 --decode -i profile.mobileprovision.base64 -o profile.mobileprovision.base64
+          base64 --decode cert.p12.base64 > cert.p12
+          base64 --decode profile.mobileprovision.base64 > profile.mobileprovision
           turtle build:ios --type=archive --build-dir=. --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
         env:
           EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v*
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - uses: actions/cache@v2
+        with:
+          path: ~/.turtle
+          key: ${{ runner.os }}-turtle
+          restore-keys: |
+            ${{ runner.os }}-turtle
+      - uses: actions/setup-java@v1.4.3
+        with:
+          java-version: '8'
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-cache: true
+          expo-token: ${{ secrets.EXPO_TOKEN }}
+      - run: yarn
+      - run: expo doctor
+      - run: expo diagnostics
+      - run: expo export --clear --force --dev --public-url http://localhost:5000 --output-dir dist
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist/
+
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-cache: true
+          expo-token: ${{ secrets.EXPO_TOKEN }}
+      - run: npx serve dist &
+      - run: |
+          echo "$EXPO_ANDROID_KEYSTORE_BASE64" > keystore.jks.base64
+          base64 --decode keystore.jks.base64 > keystore.jks
+          yarn build:local:android -- --public-url http://localhost:5000/android-index.json --allow-non-https-public-url --keystore-path ./keystore.jks --keystore-alias $EXPO_ANDROID_KEYSTORE_ALIAS
+        env:
+          EXPO_ANDROID_KEYSTORE_BASE64: ${{ secrets.EXPO_ANDROID_KEYSTORE_BASE64 }}
+          EXPO_ANDROID_KEYSTORE_ALIAS: ${{ secrets.EXPO_ANDROID_KEYSTORE_ALIAS }}
+          EXPO_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.EXPO_ANDROID_KEYSTORE_PASSWORD }}
+          EXPO_ANDROID_KEY_PASSWORD: ${{ secrets.EXPO_ANDROID_KEY_PASSWORD }}
+      - run: |
+          echo "$PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON" > play-store-account-key.json
+          expo upload:android --key ./play-store-account-key.json --path ./build/polaris.apk --type apk --release-status draft
+        env:
+          PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_KEY_JSON }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - run: |
           echo "$EXPO_ANDROID_KEYSTORE_BASE64" > keystore.jks.base64
           base64 --decode keystore.jks.base64 > keystore.jks
-          yarn build:local:android -- --public-url http://localhost:5000/android-index.json --allow-non-https-public-url --keystore-path ./keystore.jks --keystore-alias $EXPO_ANDROID_KEYSTORE_ALIAS
+          yarn build:local:android -- --type=apk --output=build/polaris.apk --public-url=http://localhost:5000/android-index.json --allow-non-https-public-url --keystore-path=./keystore.jks --keystore-alias=$EXPO_ANDROID_KEYSTORE_ALIAS
         env:
           EXPO_ANDROID_KEYSTORE_BASE64: ${{ secrets.EXPO_ANDROID_KEYSTORE_BASE64 }}
           EXPO_ANDROID_KEYSTORE_ALIAS: ${{ secrets.EXPO_ANDROID_KEYSTORE_ALIAS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,32 @@ jobs:
         with:
           name: build
           path: build/
+
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - run: npx serve dist &
+      - run: |
+          echo "$EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64" > cert.p12.base64
+          echo "$EXPO_IOS_PROVISIONING_PROFILE_BASE64" > profile.mobileprovision.base64
+          base64 --decode cert.p12.base64 > cert.p12
+          base64 --decode profile.mobileprovision.base64 > profile.mobileprovision
+          yarn build:local:ios -- --type=archive --output=build/polaris.ipa --allow-non-https-public-url --public-url=http://localhost:5000/ios-index.json --team-id=$EXPO_IOS_TEAM_ID --dist-p12-path=cert.p12 --provisioning-profile-path=profile.mobileprovision
+        env:
+          EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.EXPO_IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          EXPO_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.EXPO_IOS_PROVISIONING_PROFILE_BASE64 }}
+          EXPO_IOS_TEAM_ID: ${{ secrets.EXPO_IOS_TEAM_ID }}
+          EXPO_IOS_DIST_P12_PASSWORD: ${{ secrets.EXPO_IOS_DIST_P12_PASSWORD }}
+      - run: fastlane ios_release
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.IOS_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.IOS_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.IOS_API_KEY_KEY_CONTENT_BASE64 }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build/

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,10 @@
+lane :ios_release do
+  api_key = app_store_connect_api_key(
+    is_key_content_base64: true
+  )  
+  upload_to_testflight(
+    ipa: "build/polaris.ipa",
+    skip_submission: true,
+    skip_waiting_for_build_processing: true
+  )
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,31 @@
+# fastlane documentation
+
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```
+xcode-select --install
+```
+
+Install _fastlane_ using
+
+```
+[sudo] gem install fastlane -NV
+```
+
+or alternatively using `brew install fastlane`
+
+# Available Actions
+
+### ios_release
+
+```
+fastlane ios_release
+```
+
+---
+
+This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:web": "expo build:web",
     "build:ios": "expo build:ios",
     "build:android": "expo build:android",
-    "build:local:ios": "turtle build:ios --type=simulator --output=build/polaris.tgz && tar xzf build/polaris.tgz -C build",
+    "build:local:ios": "turtle build:ios",
     "build:local:android": "turtle build:android --type=apk --output=build/polaris.apk",
     "eject": "expo eject",
     "lint": "eslint --ext .js,.jsx .",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:ios": "expo build:ios",
     "build:android": "expo build:android",
     "build:local:ios": "turtle build:ios",
-    "build:local:android": "turtle build:android --type=apk --output=build/polaris.apk",
+    "build:local:android": "turtle build:android",
     "eject": "expo eject",
     "lint": "eslint --ext .js,.jsx .",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
Issue: https://github.com/nearform/polaris/issues/102

Created a new flow which builds and release both ios and android (Android was working fine, just ios was added)
Moved android upload to a new flow and kept the old e2e code (needs to be updated?... i think)

You can check the manually triggered flows that were successful here: https://github.com/nearform/polaris/actions/workflows/e2e.android.yml

Made the flow to be triggered when a new tag is created or manually.
