### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,11 @@ jobs:
     needs: export
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - run: yarn
       - uses: actions/download-artifact@v2
         with:
           name: dist
@@ -82,6 +87,11 @@ jobs:
     needs: export
     runs-on: macos-latest
     steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - run: yarn
       - uses: actions/download-artifact@v2
         with:
           name: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14.x
+      - uses: actions/setup-java@v1.4.3
+        with:
+          java-version: '8'
       - run: yarn
       - uses: actions/download-artifact@v2
         with:
@@ -91,6 +94,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14.x
+      - uses: actions/setup-java@v1.4.3
+        with:
+          java-version: '8'
       - run: yarn
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: release
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - release/*
   push:
     tags:
       - v*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           path: dist/
 
   android:
+    needs: export
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -78,6 +79,7 @@ jobs:
           path: build/
 
   ios:
+    needs: export
     runs-on: macos-latest
     steps:
       - uses: actions/download-artifact@v2

--- a/app.json
+++ b/app.json
@@ -21,12 +21,13 @@
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "bundleIdentifier": "com.nearform.polaris",
+      "buildNumber": "3",
       "supportsTablet": true
     },
     "android": {
       "package": "com.nearform.polaris",
-      "useNextNotificationsApi": true,
-      "versionCode": 2
+      "versionCode": 3,
+      "useNextNotificationsApi": true
     },
     "web": {
       "favicon": "./src/assets/favicon.png"

--- a/src/components/views/settings/index.jsx
+++ b/src/components/views/settings/index.jsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
+import { Text } from 'react-native'
 import { useTranslation } from 'react-i18next'
+import * as Application from 'expo-application'
 import styled from 'styled-components/native'
 import Container from 'components/atoms/container'
 import SettingItem from 'components/molecules/setting-item'
@@ -17,6 +19,14 @@ export const Settings = () => {
       <SettingItem
         label={t('settings:languageLabel')}
         value={<LanguageSelector />}
+      />
+      <SettingItem
+        label={t('settings:versionLabel')}
+        value={
+          <Text>
+            {`${Application.nativeApplicationVersion} (${Application.nativeBuildVersion})`}
+          </Text>
+        }
       />
     </Page>
   )

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -53,7 +53,8 @@
   },
   "settings": {
     "title": "Settings",
-    "languageLabel": "Language:"
+    "languageLabel": "Language:",
+    "versionLabel": "Version:"
   },
   "camera": {
     "title": "Camera",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -50,7 +50,8 @@
   },
   "settings": {
     "title": "Impostazioni",
-    "languageLabel": "Lingua:"
+    "languageLabel": "Lingua:",
+    "versionLabel": "Versione:"
   },
   "camera": {
     "title": "Fotocamera",


### PR DESCRIPTION
See https://github.com/nearform/polaris/actions/runs/730272743.  Fails are due to re-submitting.

@Reviewer: should we add branch `release/*` as the trigger for this (or maybe replace tags)?

TODO (draft):
- [x] show version in Polaris
- [x] increase version to automatically publish it
- [ ] ios yarn cache (discuss)